### PR TITLE
Bump dash dependency to 2.18

### DIFF
--- a/org-starter.el
+++ b/org-starter.el
@@ -4,7 +4,7 @@
 
 ;; Author: Akira Komamura <akira.komamura@gmail.com>
 ;; Version: 0.2.9
-;; Package-Requires: ((emacs "25.1") (dash "2.12") (dash-functional "1.2.0"))
+;; Package-Requires: ((emacs "25.1") (dash "2.18"))
 ;; URL: https://github.com/akirak/org-starter
 
 ;; This file is not part of GNU Emacs.
@@ -34,7 +34,6 @@
 (require 'cl-lib)
 (require 'subr-x)
 (require 'dash)
-(require 'dash-functional)
 (require 'org-capture)
 
 (declare-function posframe-show "ext:posframe")


### PR DESCRIPTION
dash-functional is deprecated. See https://github.com/magnars/dash.el/blob/master/NEWS.md#from-217-to-218

I noticed this change thanks to @basil-conto at https://github.com/alphapapa/frame-purpose.el/pull/18