### PR TITLE
Optimize recentf exclusion checks

### DIFF
--- a/org-starter.el
+++ b/org-starter.el
@@ -432,13 +432,13 @@ OBJ should be a symbol, or a list of symbols."
 
 (defun org-starter-recentf-excluded-p (file)
   "Check if FILE is an org-starter file that should be excluded from recentf."
-  (and (listp org-starter-exclude-from-recentf)
+  (and (string-match-p org-agenda-file-regexp file)
+       (listp org-starter-exclude-from-recentf)
        org-starter-exclude-from-recentf
        (or (and (memq 'known-files org-starter-exclude-from-recentf)
                 (cl-member file org-starter-known-files
                            :test #'file-equal-p))
            (and (memq 'path org-starter-exclude-from-recentf)
-                (string-match-p org-agenda-file-regexp file)
                 (cl-member (file-name-directory file) org-starter-path
                            :test #'file-equal-p)))))
 

--- a/org-starter.el
+++ b/org-starter.el
@@ -243,6 +243,17 @@ If this variable is nil, it doesn't take effect, and the same
                  (const other-frame)
                  (const nil)))
 
+(defcustom org-starter-check-truename t
+  "Whether to compare file names according to true names.
+
+When this option is t, it compares file names by true names in
+several functions. This is accurate if you store org files in
+symlinked directories, but it is slower.
+
+Set the value to nil if your org files don't involve symlinks."
+  :group 'org-starter
+  :type 'boolean)
+
 ;;;; Variables
 (defvar org-starter-suppress-override-messages-once nil)
 
@@ -278,6 +289,9 @@ value of `enable-local-variables`."
 
 This is updated by `org-starter-define-directory'.
 The user should not update this value.")
+
+(defvar org-starter-truename-cache nil
+  "Hash table used to store true names of files and directories.")
 
 ;;;###autoload
 (define-minor-mode org-starter-mode
@@ -422,6 +436,33 @@ OBJ should be a symbol, or a list of symbols."
    ((symbolp obj) (list obj))
    ((listp obj) obj)))
 
+(cl-defun org-starter--file-member-p (file list &key expand)
+  "Return non-nil if the file is included in the list.
+
+FILE is an absolute path to a file, and LIST is a list of files.
+
+If EXPAND is non-nil, use `expand-file-name' to expand abbreviate
+file names. It doesn't take effect if
+`org-starter-check-truename' is non-nil."
+  (cond
+   (org-starter-check-truename
+    (cl-member file list :test #'equal
+               :key #'org-starter--cached-truename))
+   (expand
+    (cl-member file list :test #'equal :key #'expand-file-name))
+   (t
+    (member file list))))
+
+(defun org-starter--cached-truename (file)
+  "Return the true name of FILE, from a cache value if available."
+  (unless org-starter-truename-cache
+    (setq org-starter-truename-cache
+          (make-hash-table :test #'equal)))
+  (or (gethash file org-starter-truename-cache)
+      (let ((truename (file-truename file)))
+        (puthash file truename org-starter-truename-cache)
+        truename)))
+
 ;;;; Exclude files in org-starter from recentf
 
 (defcustom org-starter-exclude-from-recentf nil
@@ -431,16 +472,16 @@ OBJ should be a symbol, or a list of symbols."
               (const :tag "Exclude files in path" 'path)))
 
 (defun org-starter-recentf-excluded-p (file)
-  "Check if FILE is an org-starter file that should be excluded from recentf."
+  "Return non-nil if FILE should be excluded from recentf."
   (and (string-match-p org-agenda-file-regexp file)
        (listp org-starter-exclude-from-recentf)
        org-starter-exclude-from-recentf
        (or (and (memq 'known-files org-starter-exclude-from-recentf)
-                (cl-member file org-starter-known-files
-                           :test #'file-equal-p))
+                (org-starter--file-member-p (expand-file-name file)
+                                            org-starter-known-files))
            (and (memq 'path org-starter-exclude-from-recentf)
-                (cl-member (file-name-directory file) org-starter-path
-                           :test #'file-equal-p)))))
+                (org-starter--file-member-p (file-name-directory file)
+                                            org-starter-path)))))
 
 (add-hook 'recentf-exclude #'org-starter-recentf-excluded-p t)
 


### PR DESCRIPTION
This package provides a feature which excludes org files from recentf according to the user's preference. 

However, it was slow because it uses `file-equal-p` which internally calls `file-truename`. This PR makes the recentf check faster by minimizing calls of `file-truename`. Also added `org-starter-check-truename` custom variable which allows the user to disable truename comparison. Other functions in the package should respect this setting, which I may work on in the future.